### PR TITLE
add ctools dependecie

### DIFF
--- a/mega_menu.info.yml
+++ b/mega_menu.info.yml
@@ -5,3 +5,4 @@ core: 8.x
 dependencies:
   - layout_plugin
   - menu_link_content
+  - ctools


### PR DESCRIPTION
To fix errors like:
Error: Class 'Drupal\ctools\Plugin\BlockPluginCollection' not found in /var/www/drupal8/modules/mega_menu/src/Entity/MegaMenu.php on line 135
